### PR TITLE
fix: dimensions GUI -> crash on server without mod

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/events/client/KeyBoardEventListener.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/events/client/KeyBoardEventListener.java
@@ -1,5 +1,6 @@
 package com.pg85.otg.forge.events.client;
 
+import com.pg85.otg.OTG;
 import com.pg85.otg.forge.dimensions.OTGDimensionManager;
 import com.pg85.otg.forge.dimensions.OTGWorldProvider;
 import com.pg85.otg.forge.gui.OTGGuiDimensionList;
@@ -32,10 +33,15 @@ public class KeyBoardEventListener
 			}
 			if (ClientProxy.otgInGameUIKeyBinding.isPressed())
 			{
-				// Only open the menu for overworld or OTG dimensions
 		    	if(
-					Minecraft.getMinecraft().world != null && 
-					Minecraft.getMinecraft().world.provider != null && 
+					// The GUI screen requires the dimensions configuration to be available, so it shouldn't be opened
+					// with an unset configuration.
+                    // This is the case when connecting to servers without the mod installed, for example.
+					OTG.GetDimensionsConfig() != null &&
+
+					// Only open the menu for overworld or OTG dimensions
+					Minecraft.getMinecraft().world != null &&
+					Minecraft.getMinecraft().world.provider != null &&
 					(
     					Minecraft.getMinecraft().world.provider.getDimension() == 0 ||
     					Minecraft.getMinecraft().world.provider instanceof OTGWorldProvider
@@ -44,7 +50,7 @@ public class KeyBoardEventListener
 	        	{
 	        		Minecraft.getMinecraft().displayGuiScreen(new OTGGuiDimensionList(null));
 	        	}
-			}				
+			}
 		}
 	}
 }


### PR DESCRIPTION
When the dimensions GUI was opened (default keybind: o) on a server
without the forge version of this mod installed, the game would
previously crash.